### PR TITLE
global match to regExp

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,7 +35,7 @@ module.exports = function (size, ifile) {
         ifile && glob(ifile,function(err, files){
             if(err) return console.log(err);
             files.forEach(function(ilist){
-              var result = fs.readFileSync(ilist,'utf8').replace(new RegExp(escapeRegExp(sub_namepath + filename)), sub_namepath + md5_filename);
+              var result = fs.readFileSync(ilist,'utf8').replace(new RegExp(escapeRegExp(sub_namepath + filename), "g"), sub_namepath + md5_filename);
                 fs.writeFileSync(ilist, result, 'utf8');
             })
         })


### PR DESCRIPTION
Added a global match to regExp. It will fix the renaming duplicated files when using "src" and "srcset" in <img>/HTML.
src="img/flower_300.jpg" srcset="img/flower_300.jpg 300w, img/flower_500.jpg 500w"
