### PR TITLE
Stop creating new bundles

### DIFF
--- a/index.js
+++ b/index.js
@@ -41,8 +41,6 @@ module.exports = function (size, ifile) {
             })
         })
 
-        file.path = path.join(dir, md5_filename);
-
         this.push(file);
         cb();
     }, function (cb) {


### PR DESCRIPTION
It is just needed to add the md5 hash in the quote link, not create a new file. 

eg.:  

This: `<script type="text/javascript" src="/bundles/js/app.js?49cb77fa6a"></script>`

links to this: `app.js`

Doesn't need hash in the bundle file.